### PR TITLE
feat: add fastapi skeleton and ai schema

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,23 @@
+# FastAPI Backend Skeleton
+
+This directory contains a minimal FastAPI application implementing the core endpoints described in the generative AI specification.
+
+## Endpoints
+- `POST /api/lead/intake`
+- `POST /api/chat`
+- `POST /api/pdf/proposal`
+- `POST /api/payment/create`
+- `POST /webhooks/whatsapp`
+- `POST /webhooks/mercadopago`
+
+All handlers are placeholders and require implementation for production use.
+
+## Development
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+Run the server:
+```bash
+uvicorn main:app --reload
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,90 @@
+from fastapi import FastAPI, Request, HTTPException
+from pydantic import BaseModel
+import httpx
+import os
+import json
+
+app = FastAPI()
+
+class LeadIntake(BaseModel):
+    name: str | None = None
+    email: str | None = None
+    phone: str | None = None
+    country: str | None = None
+    interest: str
+    message: str | None = None
+    turnstile_token: str
+
+class ChatRequest(BaseModel):
+    lead_id: str
+    message: str
+
+class PDFRequest(BaseModel):
+    lead_id: str
+    product: str
+    language: str = "es"
+
+class PaymentRequest(BaseModel):
+    lead_id: str
+    product: str
+
+async def call_llm(system: str, user: str) -> str:
+    """Placeholder for LLM provider call."""
+    # TODO: integrate with real LLM provider
+    return '{}'
+
+async def verify_turnstile(token: str, ip: str) -> bool:
+    secret = os.environ.get("TURNSTILE_SECRET", "")
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+            data={"secret": secret, "response": token, "remoteip": ip},
+            timeout=10,
+        )
+    data = r.json()
+    return data.get("success", False)
+
+@app.post("/api/lead/intake")
+async def intake(payload: LeadIntake, request: Request):
+    if not await verify_turnstile(payload.turnstile_token, request.client.host):
+        raise HTTPException(status_code=400, detail="turnstile_failed")
+    prompt_sys = "Eres un analista comercial de MELANO INC. Devuelves JSON."
+    prompt_user = json.dumps({
+        "name": payload.name,
+        "email": payload.email,
+        "phone": payload.phone,
+        "country": payload.country,
+        "interest": payload.interest,
+        "message": payload.message or "",
+    })
+    out = await call_llm(prompt_sys, prompt_user)
+    # TODO: parse JSON, store in Supabase, compute next actions
+    return {"lead_id": "placeholder", "score": 0, "next_actions": []}
+
+@app.post("/api/chat")
+async def chat(payload: ChatRequest):
+    # TODO: implement chat logic with LLM and RAG
+    return {"reply": "", "suggested_next": [], "logs_id": None}
+
+@app.post("/api/pdf/proposal")
+async def pdf_proposal(payload: PDFRequest):
+    # TODO: render proposal and upload to Supabase Storage
+    return {"pdf_url": ""}
+
+@app.post("/api/payment/create")
+async def payment_create(payload: PaymentRequest):
+    # TODO: integrate with MercadoPago to create checkout
+    return {"checkout_url": "", "order_id": ""}
+
+@app.post("/webhooks/whatsapp")
+async def whatsapp_webhook(request: Request):
+    payload = await request.json()
+    # TODO: handle WhatsApp webhook, route via AI, log conversation
+    return {"ok": True}
+
+@app.post("/webhooks/mercadopago")
+async def mercadopago_webhook(request: Request):
+    payload = await request.json()
+    # TODO: update order status and trigger fulfilment workflow
+    return {"ok": True}
+

--- a/backend/prompts.py
+++ b/backend/prompts.py
@@ -1,0 +1,17 @@
+"""Prompt templates for LLM interactions."""
+
+LEAD_SCORING_SYSTEM = (
+    "Eres un analista comercial de MELANO INC. Devuelves JSON."
+)
+
+WHATSAPP_CTA_SYSTEM = (
+    "Asistente de ventas premium MELANO INC. Breve, directo, autoridad."
+)
+
+PDF_PROPOSAL_SYSTEM = (
+    "Redactor senior B2B. Marca: MELANO INC (AI. Automation. Impact.)"
+)
+
+RAG_QA_SYSTEM = (
+    "Responde solo con info de contexto. Si falta dato, dilo y ofrece next step."
+)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+pydantic

--- a/supabase/migrations/20250818000000_ai_schema.sql
+++ b/supabase/migrations/20250818000000_ai_schema.sql
@@ -1,0 +1,53 @@
+-- Lead and conversation tracking for generative AI workflows
+create table leads (
+  id uuid primary key default gen_random_uuid(),
+  source text check (source in ('web','whatsapp','email')) not null,
+  name text,
+  email text,
+  phone text,
+  country text,
+  interest text,
+  details jsonb,
+  status text default 'new',
+  score integer default 0,
+  score_reasons text,
+  created_at timestamptz default now()
+);
+
+create table conversations (
+  id uuid primary key default gen_random_uuid(),
+  lead_id uuid references leads(id),
+  channel text,
+  role text,
+  message text,
+  metadata jsonb,
+  created_at timestamptz default now()
+);
+
+create table docs (
+  id uuid primary key default gen_random_uuid(),
+  title text,
+  tags text[],
+  url text,
+  content text,
+  created_at timestamptz default now()
+);
+
+create table doc_chunks (
+  id uuid primary key default gen_random_uuid(),
+  doc_id uuid references docs(id),
+  chunk text,
+  embedding vector(1536)
+);
+
+create table orders (
+  id uuid primary key default gen_random_uuid(),
+  lead_id uuid references leads(id),
+  product text,
+  price numeric,
+  currency text default 'ARS',
+  status text,
+  mp_preference_id text,
+  mp_payment_id text,
+  created_at timestamptz default now()
+);


### PR DESCRIPTION
## Summary
- add FastAPI backend skeleton with intake, chat, pdf, payment, and webhook endpoints
- include placeholder prompt templates for LLM usage
- define Supabase schema for leads, conversations, docs, embeddings, and orders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a277208afc83248afb35ae5f7f9d04

## Resumen por Sourcery

Proporciona una estructura de aplicación FastAPI fundamental junto con un esquema de IA de Supabase y los prompts y dependencias necesarios.

Nuevas Características:
- Estructura un backend FastAPI con endpoints para la captación de leads, chat, propuesta en PDF, creación de pagos y webhooks para WhatsApp y MercadoPago

Mejoras:
- Añade modelos Pydantic de marcador de posición y funciones de utilidad para llamadas a LLM y verificación de Turnstile
- Incluye plantillas de prompts para varias interacciones de IA en prompts.py

Construcción:
- Añade un archivo de requisitos de Python con FastAPI, uvicorn, httpx y Pydantic

Documentación:
- Añade un README que describe los endpoints de la API y la configuración de desarrollo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a foundational FastAPI application structure alongside a Supabase AI schema and necessary prompts and dependencies

New Features:
- Scaffold FastAPI backend with endpoints for lead intake, chat, PDF proposal, payment creation, and webhooks for WhatsApp and MercadoPago

Enhancements:
- Add placeholder Pydantic models and utility functions for LLM calls and Turnstile verification
- Include prompt templates for various AI interactions in prompts.py

Build:
- Add Python requirements file with FastAPI, uvicorn, httpx, and Pydantic

Documentation:
- Add README outlining API endpoints and development setup

</details>